### PR TITLE
POST Request to Backend with Message as Body

### DIFF
--- a/src/backend-request/index.js
+++ b/src/backend-request/index.js
@@ -5,10 +5,9 @@ export const API_BASE_URL =
 
 export const request = (endpoint, method = "GET", body) =>
   fetch(`${API_BASE_URL}/${endpoint}`, {
-    method,
     headers: {
-      "content-type": "application/json",
-      method,
-      body
-    }
+      "Content-Type": "application/json",
+    },
+    method,
+    body: JSON.stringify(body)
   });

--- a/src/components/Home/Homepage.js
+++ b/src/components/Home/Homepage.js
@@ -9,7 +9,7 @@ export const Homepage = () => {
   const [data, setData] = useState([]);
 
   useEffect(() => {
-    fetch(API_BASE_URL + "/previous-polls")
+    fetch(API_BASE_URL + "/polls")
       .then(res => res.json())
       .then(data => {
         // return _data.concat(data);

--- a/src/components/NewPoll/NewPollForm.js
+++ b/src/components/NewPoll/NewPollForm.js
@@ -17,6 +17,7 @@ const NewPollForm = ({
   updateChannelID,
   updateChannelSize,
   fetchChannels,
+  postMessages,
   message,
   channels
 }) => {
@@ -27,7 +28,7 @@ const NewPollForm = ({
   const handleSubmitPoll = e => {
     e.preventDefault();
     validResponse(message.responses)
-      ? console.log("submit poll")
+      ? postMessages()
       : alert("Please complete the response");
   };
 
@@ -126,7 +127,8 @@ const mapDispatchToProps = dispatch => ({
     dispatch(messageAction.updateChannelID(newChannelID)),
   updateChannelSize: newChannelSize =>
     dispatch(messageAction.updateChannelSize(newChannelSize)),
-  fetchChannels: () => dispatch(channelAction.fetchChannelsThunk())
+  fetchChannels: () => dispatch(channelAction.fetchChannelsThunk()),
+  postMessages: () => dispatch(messageAction.postMessagesThunk())
 });
 
 export const ConnectedNewPollForm = connect(

--- a/src/redux/messageActions.js
+++ b/src/redux/messageActions.js
@@ -1,3 +1,5 @@
+import { API_BASE_URL, request } from "../backend-request/index";
+
 export const message = {
   UPDATE_QUESTION: "UPDATE_QUESTION",
   UPDATE_ANSWERS: "UPDATE_ANSWERS",
@@ -30,3 +32,14 @@ export const updateChannelSize = newChannelSize => ({
   type: message.UPDATE_CHANNEL_SIZE,
   data: newChannelSize
 });
+
+// Post Messages to Backend Thunk
+export const postMessagesThunk = () => (dispatch, getState) => {
+  return request("new-poll", 'POST', getState().message)
+    .then(() => {
+      console.log('data has been sent to back end')
+    })
+    .catch(error => {
+      console.log(error);
+    })
+};

--- a/src/redux/messageActions.js
+++ b/src/redux/messageActions.js
@@ -35,7 +35,7 @@ export const updateChannelSize = newChannelSize => ({
 
 // Post Messages to Backend Thunk
 export const postMessagesThunk = () => (dispatch, getState) => {
-  return request("new-poll", 'POST', getState().message)
+  return request("polls", 'POST', getState().message)
     .then(() => {
       console.log('data has been sent to back end')
     })


### PR DESCRIPTION
**PROBLEM**
Needs to communicate the poll message (question, response(s), channel selected) created to backend. 

**SOLUTION**
- Moved the body and method out of the header key in the request helper function
- Created postMessageThunk which utilizes the request helper function to post message from state to backend 
- Dispatched the thunk on form submit